### PR TITLE
Add workflow to run data tests

### DIFF
--- a/.github/workflows/data_tests.yml
+++ b/.github/workflows/data_tests.yml
@@ -1,0 +1,31 @@
+name: Data Tests
+
+on: [push, pull_request]
+
+jobs:
+  duplicate_entries:
+    name: Duplicate entries
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+
+    steps:
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.x
+
+    - name: Check out data
+      uses: actions/checkout@v2.3.4
+      with:
+        path: data
+
+    - name: Check out data tests
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: openelections/openelections-data-tests
+        ref: v0.1.1
+        path: data_tests
+
+    - name: Run data tests
+      run: python3 ${{ github.workspace }}/data_tests/run_tests.py duplicate_entries ${{ github.workspace }}/data

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-[![Build Status](https://github.com/openelections/openelections-data-id/actions/workflows/data_tests.yml/badge.svg?branch=master)](https://github.com/openelections/openelections-data-id/actions)
-[![Build Status](https://github.com/openelections/openelections-data-id/actions/workflows/format_tests.yml/badge.svg?branch=master)](https://github.com/openelections/openelections-data-id/actions)
+[![Build Status](https://github.com/openelections/openelections-data-id/actions/workflows/data_tests.yml/badge.svg?branch=master)](https://github.com/openelections/openelections-data-id/actions/workflows/data_tests.yml?query=branch%3Amaster)
+[![Build Status](https://github.com/openelections/openelections-data-id/actions/workflows/format_tests.yml/badge.svg?branch=master)](https://github.com/openelections/openelections-data-id/actions/workflows/format_tests.yml?query=branch%3Amaster)
 
 # openelections-data-id
 Pre-processed results for Idaho elections

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
-# openelections-data-id [![Build Status](https://github.com/openelections/openelections-data-id/actions/workflows/format_tests.yml/badge.svg?branch=master)](https://github.com/openelections/openelections-data-id/actions)
+[![Build Status](https://github.com/openelections/openelections-data-id/actions/workflows/data_tests.yml/badge.svg?branch=master)](https://github.com/openelections/openelections-data-id/actions)
+[![Build Status](https://github.com/openelections/openelections-data-id/actions/workflows/format_tests.yml/badge.svg?branch=master)](https://github.com/openelections/openelections-data-id/actions)
+
+# openelections-data-id
 Pre-processed results for Idaho elections
 
 Idaho [makes available for download](http://www.sos.idaho.gov/ELECT/results/index.html) Excel files with both county and precinct-level results. We are interested in the files marked `Statewide`, `Presidential` and `Legislature` at both the county and precinct levels for primary and general elections dating back to 2000 (although we'd happily accept earlier stuff, too).


### PR DESCRIPTION
This adds a workflow to run the [data validation](https://github.com/openelections/openelections-data-tests) tests.  This currently consists of a single job that checks for duplicate entries in the data files.

