### PR TITLE
Bump data tests to version 1.0.0

### DIFF
--- a/.github/workflows/data_tests.yml
+++ b/.github/workflows/data_tests.yml
@@ -3,11 +3,16 @@ name: Data Tests
 on: [push, pull_request]
 
 jobs:
-  duplicate_entries:
-    name: Duplicate entries
+  data_tests:
+    name: Data tests
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
+      matrix:
+        test: [duplicate_entries, missing_values, vote_breakdown_totals]
+
+    env:
+      LOG_FILE: ${{ github.workspace }}/${{ matrix.test }}.txt
 
     steps:
     - name: Set up Python
@@ -24,8 +29,15 @@ jobs:
       uses: actions/checkout@v2.3.4
       with:
         repository: openelections/openelections-data-tests
-        ref: v0.1.1
+        ref: v1.0.0
         path: data_tests
 
     - name: Run data tests
-      run: python3 ${{ github.workspace }}/data_tests/run_tests.py duplicate_entries ${{ github.workspace }}/data
+      run: python3 ${{ github.workspace }}/data_tests/run_tests.py --log-file=${{ env.LOG_FILE }} ${{ matrix.test }} ${{ github.workspace }}/data
+
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v2.2.4
+      if: failure()
+      with:
+        name: ${{ matrix.test }}_full_logs
+        path: ${{ env.LOG_FILE }}


### PR DESCRIPTION
This bumps the data tests to [version 1.0.0](https://github.com/openelections/openelections-data-tests/releases/tag/v1.0.0). In doing so, we add new jobs to verify vote breakdown totals and detect missing entries. In addition, failed jobs will now create artifacts with logs files containing the full failure messages.